### PR TITLE
ci: parallelizes build tasks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,19 +6,60 @@ on:
   pull_request:
 
 jobs:
-  publish:
+  setup:
     runs-on: ubuntu-latest
-    name: Publish
+    name: Setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: dep-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Install
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: yarn 
+  build-frontend:
+    runs-on: ubuntu-latest
+    name: Build frontend
+    needs: setup
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         id: node-setup
         with:
           node-version: 16
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install
         run: yarn
       - name: Build
         run: yarn build:frontend
+      - uses: actions/upload-artifact@v2
+        with:
+          name: frontend-dist
+          path: dist
+  build-dictionary:
+    runs-on: ubuntu-latest
+    name: Build dictionary
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        id: node-setup
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Install
+        run: yarn
       - name: Build dictionary
         env:
           DICTIONARY_TAG: rev_22-01-2022-22-04
@@ -26,7 +67,34 @@ jobs:
         run: |
           gh release download --repo mcataford/words ${{ env.DICTIONARY_TAG }}
           yarn ts-node script/buildDictionary.ts
-      - name: Deploy preview
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dictionary
+          path: puzzles.sqlite
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish
+    needs: [build-frontend, build-dictionary]
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        id: node-setup
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Install
+        run: yarn
+      - uses: actions/download-artifact@v2
+        with:
+          name: frontend-dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dictionary
+      - name: Deploy previewi
         if: ${{ github.ref != 'refs/heads/main' }}
         id: preview-deploy
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-      - name: Install
-        run: yarn
       - name: Build
         run: yarn build:frontend
       - uses: actions/upload-artifact@v2
@@ -58,8 +56,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-      - name: Install
-        run: yarn
       - name: Build dictionary
         env:
           DICTIONARY_TAG: rev_22-01-2022-22-04
@@ -85,8 +81,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-      - name: Install
-        run: yarn
       - uses: actions/download-artifact@v2
         with:
           name: frontend-dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,8 +112,8 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
-          yarn netlify deploy > output.log
-          echo "::set-output name=draft-url::$(grep 'Website Draft URL' output.log)"
+          yarn netlify deploy --json | jq '.deploy_url' -r > deploy_url.txt
+          echo "::set-output name=draft-url::$(cat deploy_url.txt)"
       - name: Report
         if: ${{ github.ref != 'refs/heads/main' }}
         uses: actions/github-script@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,23 @@ jobs:
       - name: Install
         if: steps.dep-cache.outputs.cache-hit != 'true'
         run: yarn 
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        id: node-setup
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Lint
+        run: yarn lint
+
   build-frontend:
     runs-on: ubuntu-latest
     name: Build frontend
@@ -70,7 +87,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish
-    needs: [build-frontend, build-dictionary]
+    needs: [lint, build-frontend, build-dictionary]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish
     needs: [build-frontend, build-dictionary]
-    needs: setup
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,10 +84,11 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: frontend-dist
+          path: dist
       - uses: actions/download-artifact@v2
         with:
           name: dictionary
-      - name: Deploy previewi
+      - name: Deploy preview
         if: ${{ github.ref != 'refs/heads/main' }}
         id: preview-deploy
         env:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "yarn netlify dev",
     "lint:fix": "yarn eslint packages/**/src/**/*.(t|j)s script/*.(t|j)s --fix",
+    "lint": "yarn eslint packages/**/src/**/*.(t|j)s script/*.(t|j)s",
     "build:frontend": "yarn parcel build packages/frontend/src/index.html --dist-dir ./dist"
   },
   "devDependencies": {

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -29,12 +29,12 @@ function draw(state: GameState) {
     cellTable.id = 'game-grid'
     for (let height = 0; height < state.puzzleSize; height++) {
         const row = document.createElement('div')
-        row.className = "row"
+        row.className = 'row'
         const currentWord = letters.length > 0 ? letters.shift() : []
 
         for (let width = 0; width < state.puzzleSize; width++) {
             const cell = document.createElement('div')
-            cell.className = "cell"
+            cell.className = 'cell'
 
             if (width < currentWord.length) {
                 const cellData = currentWord[width]

--- a/script/buildDictionary.ts
+++ b/script/buildDictionary.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { promises as fs } from 'fs'
 
 import * as sqlite3 from 'sqlite3'


### PR DESCRIPTION
- Parallelizes build tasks (FE, dictionary);
- Adds linting;
- Fixes PR comment logic to remove extraneous ANSI colour sequence;
- Adds caching to steps that need to `yarn` to avoid redundant `yarn install` calls

Closes #3 